### PR TITLE
Remove the 'check' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,26 +55,6 @@ A sample `converge` run can be done this way:
 sure-deploy converge --host <SWARMHOST> <STACKNAME>
 ```
 
-### `check` (Deprecated)
-
-**DEPRECATED**: Use the `verify` command below, it supports parsing your
-`docker-compose.yml`, so the deployments it supports are more universal.
-
-After a `docker swarm` deployment has converged it might have ended in one of
-two states:
-
-1. The deployment succeeded. Congratulations, you are good to go.
-2. The deployment failed. This might be due to any number of things. Maybe the
-   configuration was invalid, the containers could not be started or have been
-   rolled back.
-
-After a deployment you have to check. The `check` subcommand does exactly this:
-checks whether the deployment was successful.
-
-What `check` currently supports is to make sure all images run the same image,
-passed on the command line. This is clearly not a comprehensive works-for-all
-solution, for a more universal solution use the `verify` command.
-
 ### `verify`
 
 After a `docker swarm` deployment has converged it might have ended in one of

--- a/src/lib/requests.ml
+++ b/src/lib/requests.ml
@@ -54,13 +54,6 @@ let services swarm stack =
   resp
   |> List.map ~f:fst
 
-let images swarm stack =
-  let open Deferred.Or_error.Let_syntax in
-  let%map resp = service_images swarm stack in
-  resp
-  |> List.map ~f:snd
-  |> List.dedup_and_sort
-
 let status swarm service_name =
   let host, port = Swarm.to_host_and_port swarm in
   let url = Uri.make ~scheme:"http" ~host ~port

--- a/src/lib/swarm_types.ml
+++ b/src/lib/swarm_types.ml
@@ -50,7 +50,6 @@ module Image : sig
   val to_string : t -> string
   val equal_nametag : t -> t -> bool
   val of_yojson : Yojson.Safe.json -> (t, string) result
-  val has_prefix : t -> prefix:string -> bool
 end = struct
   type t = string
   let of_string = Fn.id
@@ -71,8 +70,6 @@ end = struct
     let a = basename a in
     let b = basename b in
     String.equal a b
-
-  let has_prefix = String.is_prefix
 end
 
 module Swarm : sig


### PR DESCRIPTION
Since this option is only a very minimal hack to avoid actually parsing YAML files and we can actually do this now there is no need to continue to support this function in the future. It only supports a very basic usecase which is completely covered by the way more flexible `verify` option anyway.

No need to confuse users with options we don't want them to be using anyway.