### PR TITLE
Image hash verification

### DIFF
--- a/src/lib/dune
+++ b/src/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name lib)
  (libraries core async cohttp-async yojson ppx_deriving_yojson.runtime yaml variable)
- (preprocess (pps ppx_deriving_yojson ppx_let)))
+ (preprocess (pps ppx_deriving.eq ppx_deriving_yojson ppx_let)))

--- a/src/lib/requests.ml
+++ b/src/lib/requests.ml
@@ -80,7 +80,7 @@ let finished swarm service_name =
 let v2_manifest = "application/vnd.docker.distribution.manifest.v2+json"
 
 let image_digest ~registry ~name ~tag =
-  let url = Uri.make ~scheme:"https" ~host:registry ~port:80
+  let url = Uri.make ~scheme:"https" ~host:registry
     ~path:(Printf.sprintf "/v2/%s/manifests/%s" name tag) ()
   in
   let headers = Cohttp.Header.init_with "Accept" v2_manifest in


### PR DESCRIPTION
If the tags do not match it can still be the same because the hash is the same. Verify if this is the case.

Closes #11.