### PR TITLE
Install required runtime dependencies for Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM alpine:3.9
 ENTRYPOINT ["/usr/local/bin/sure-deploy"]
 WORKDIR /home/opam
 RUN apk update && \
-  apk add tzdata && \
+  apk add tzdata libffi libressl2.7-libcrypto libressl2.7-libssl && \
   adduser -D opam && \
   touch /home/opam/docker-compose.yml
 USER opam


### PR DESCRIPTION
This solves the issue you've run into the other day. These packages are not installed in Alpine 3.9 so whenever the binary started it failed to load.