### PR TITLE
Make sure-deploy build again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam2:alpine-3.9-ocaml-4.07 as builder
+FROM ocaml/opam2:alpine-3.10-ocaml-4.07 as builder
 ENV OPAMYES=1
 COPY sure-deploy.opam /home/opam/sure-deploy/
 RUN git -C /home/opam/opam-repository pull --quiet && \
@@ -11,7 +11,7 @@ COPY dune-project .ocamlformat src /home/opam/sure-deploy/
 RUN (cd /home/opam/sure-deploy; sudo chown -R opam .; opam exec -- dune build @fmt @install) && \
   opam install sure-deploy
 
-FROM alpine:3.9
+FROM alpine:3.10
 ENTRYPOINT ["/usr/local/bin/sure-deploy"]
 WORKDIR /home/opam
 RUN apk update && \

--- a/sure-deploy.opam
+++ b/sure-deploy.opam
@@ -14,5 +14,6 @@ depends: [
   "cohttp-async" {>= "2.1.1"}
   "cohttp" {>= "2.1.2"}
   "yaml" {>= "2.0.0"}
+  "yojson" {> "1.4" & < "1.6"}
 ]
 


### PR DESCRIPTION
I'm declaring Alpine 3.9 a lost cause, it fails with linking errors, so let's go to 3.10 instead.

Also we trigger the Yojson deprecation warning so let's lock that in the meantime.