### PR TITLE
Inline test for image name parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,7 @@ docker-push:
 .PHONY: format
 format:
 	dune build @fmt --auto-promote @install
+
+.PHONY: test
+test:
+	dune runtest --force

--- a/src/lib/dune
+++ b/src/lib/dune
@@ -2,5 +2,6 @@
  (name lib)
  (libraries core async cohttp-async yojson ppx_deriving_yojson.runtime yaml
    variable)
+ (inline_tests)
  (preprocess
-  (pps ppx_deriving.eq ppx_deriving_yojson ppx_let)))
+  (pps ppx_deriving.eq ppx_deriving_yojson ppx_let ppx_inline_test)))

--- a/src/lib/swarm_types.ml
+++ b/src/lib/swarm_types.ml
@@ -127,11 +127,13 @@ end = struct
 
   let%test "org name tag" = equal (of_string "org/n:t") (create ~tag:"t" "org/n")
 
-  let%test "registry name" =
-    equal (of_string "registry.tld/n") (create ~registry:"registry.tld" "n")
+  let%test "registry name tag" =
+    equal (of_string "registry.tld/n:t") (create ~registry:"registry.tld" ~tag:"t" "n")
 
-  let%test "registry orgname" =
-    equal (of_string "registry.tld/org/n") (create ~registry:"registry.tld" "org/n")
+  let%test "registry orgname tag" =
+    equal
+      (of_string "registry.tld/org/n:t")
+      (create ~registry:"registry.tld" ~tag:"t" "org/n")
 
   let to_string {registry; name; tag; hash} =
     let registry_chunk =

--- a/src/lib/swarm_types.ml
+++ b/src/lib/swarm_types.ml
@@ -111,6 +111,28 @@ end = struct
           let name, tag, hash = parse_name s in
           {registry; name; tag; hash})
 
+  let create ?registry ?tag ?hash name = {name; registry; tag; hash}
+
+  let%test "plain name" = equal (of_string "n") (create "n")
+
+  let%test "org name" = equal (of_string "org/n") (create "org/n")
+
+  let%test "registry name" =
+    equal (of_string "registry.tld/n") (create ~registry:"registry.tld" "n")
+
+  let%test "registry orgname" =
+    equal (of_string "registry.tld/org/n") (create ~registry:"registry.tld" "org/n")
+
+  let%test "name tag" = equal (of_string "n:t") (create ~tag:"t" "n")
+
+  let%test "org name tag" = equal (of_string "org/n:t") (create ~tag:"t" "org/n")
+
+  let%test "registry name" =
+    equal (of_string "registry.tld/n") (create ~registry:"registry.tld" "n")
+
+  let%test "registry orgname" =
+    equal (of_string "registry.tld/org/n") (create ~registry:"registry.tld" "org/n")
+
   let to_string {registry; name; tag; hash} =
     let registry_chunk =
       match registry with

--- a/sure-deploy.opam
+++ b/sure-deploy.opam
@@ -10,6 +10,7 @@ depends: [
   "async" {>= "v0.11" & < "v0.13"}
   "async_ssl" {>= "v0.11" & < "v0.13"}
   "ppx_deriving_yojson" {>= "3.3" & < "4.0"}
+  "ppx_inline_test" {with-test & >= "v0.11" & < "v0.13"}
   "dune" {build & > "1.7"}
   "cohttp-async" {>= "2.1.1"}
   "cohttp" {>= "2.1.2"}


### PR DESCRIPTION
(Based on top of PR #22, these commits will disappear once merged)

I thought I might give this inline test thing that dune advocates a try. This is how it looks like.

It works without much ceremony but unlike Alcotest it doesn't have any printers, so it can't actually print the value that failed. Just the name of the test. I am only semi-impressed.