### PR TITLE
registry access token, insecure http registry, custom port and localhost registry support

### DIFF
--- a/src/cli/sure_deploy.ml
+++ b/src/cli/sure_deploy.ml
@@ -86,10 +86,7 @@ let match_spec_and_service
         spec_count
 
 let is_insecure_registry image insecure_registries =
-  List.mem
-    ~equal:String.equal
-    insecure_registries
-    (Image.registry_full image)
+  List.mem ~equal:String.equal insecure_registries (Image.registry_full image)
 
 let verify ~registry_access_token ~insecure_registries ~verbose host port stack
     composefile
@@ -115,13 +112,15 @@ let verify ~registry_access_token ~insecure_registries ~verbose host port stack
                      Lib.Requests.image_digest
                        ~image:deployed
                        ~registry_access_token
-                       ~is_insecure_registry:(is_insecure_registry deployed insecure_registries)
+                       ~is_insecure_registry:
+                         (is_insecure_registry deployed insecure_registries)
                    in
                    let%bind desired_hash =
                      Lib.Requests.image_digest
                        ~image:desired
                        ~registry_access_token
-                       ~is_insecure_registry:(is_insecure_registry desired insecure_registries)
+                       ~is_insecure_registry:
+                         (is_insecure_registry desired insecure_registries)
                    in
                    match String.equal deployed_hash desired_hash with
                    | true -> Deferred.Or_error.return ()

--- a/src/cli/sure_deploy.ml
+++ b/src/cli/sure_deploy.ml
@@ -85,8 +85,7 @@ let match_spec_and_service
         service_count
         spec_count
 
-let verify ~registry_access_token ~insecure_registry ~verbose host port stack
-    composefile
+let verify ~registry_access_token ~insecure_registry ~verbose host port stack composefile
   =
   let open Deferred.Or_error.Let_syntax in
   set_verbose verbose;

--- a/src/cli/sure_deploy.ml
+++ b/src/cli/sure_deploy.ml
@@ -177,20 +177,16 @@ let () =
             "--registry-access-token"
             (optional string)
             ~doc:" The access token for accessing the registry"
-        and insecureregistries =
+        and insecure_registries =
           flag
             "--insecure-registries"
-            (optional string)
+            (listed string)
             ~doc:" List of insecure registries (separated by comma)"
         and composefile =
           flag
             "--compose-file"
             (optional_with_default "docker-compose.yml" string)
             ~doc:" Compose file to read (default: docker-compose.yml)"
-        in
-        let insecure_registries = match insecureregistries with 
-          | Some insecureregistries -> String.split ~on:',' insecureregistries
-          | _ -> []
         in
         fun () ->
           verify

--- a/src/cli/sure_deploy.ml
+++ b/src/cli/sure_deploy.ml
@@ -85,7 +85,7 @@ let match_spec_and_service
         service_count
         spec_count
 
-let verify host port verbose stack composefile =
+let verify host port verbose stack registryaccesstoken composefile =
   let open Deferred.Or_error.Let_syntax in
   set_verbose verbose;
   let swarm = Swarm.of_host_and_port (host, port) in
@@ -118,12 +118,14 @@ let verify host port verbose stack composefile =
                        ~registry:deployed_registry
                        ~name:(Image.name deployed)
                        ~tag:deployed_tag
+                       ~registry_access_token:registryaccesstoken
                    in
                    let%bind desired_hash =
                      Lib.Requests.image_digest
                        ~registry:desired_registry
                        ~name:(Image.name desired)
                        ~tag:desired_tag
+                       ~registry_access_token:registryaccesstoken
                    in
                    match String.equal deployed_hash desired_hash with
                    | true -> Deferred.Or_error.return ()
@@ -179,13 +181,18 @@ let () =
           flag "--port" (optional_with_default 2375 int) ~doc:" Port to connect to"
         and verbose = flag "--verbose" no_arg ~doc:" Display more status information"
         and stack = anon ("stack-name" %: stack_name)
+        and registryaccesstoken =
+          flag
+            "--registry-access-token"
+            (optional_with_default "" string)
+            ~doc:" The access token for accessing the registry"
         and composefile =
           flag
             "--compose-file"
             (optional_with_default "docker-compose.yml" string)
             ~doc:" Compose file to read (default: docker-compose.yml)"
         in
-        fun () -> verify host port verbose stack composefile])
+        fun () -> verify host port verbose stack registryaccesstoken composefile])
   in
   Command.group
     ~summary:"Deployment helper for Docker Stack"

--- a/src/cli/sure_deploy.ml
+++ b/src/cli/sure_deploy.ml
@@ -91,13 +91,7 @@ let match_spec_and_service
 let is_insecure_registry image insecure_registries =
   List.mem ~equal:String.equal insecure_registries (Image.registry_full image)
 
-let find_registry_access_token registry_access_token_mappings image =
-  match
-    List.find registry_access_token_mappings ~f:(fun (registry, _) ->
-        String.equal registry (Image.registry_full image))
-  with
-  | None -> None
-  | Some (_, access_token) -> Some access_token
+let find_registry_access_token list image = List.Assoc.find ~equal:String.equal list (Image.registry_full image)
 
 let verify ~registry_access_tokens ~insecure_registries ~verbose host port stack
     composefile

--- a/src/cli/sure_deploy.ml
+++ b/src/cli/sure_deploy.ml
@@ -27,7 +27,7 @@ let environment () =
   >>= String.Map.of_alist_or_error
 
 let registry_access_value =
-  Command.Arg_type.create (fun s -> String.lsplit2_exn s ~on:'=')
+  Command.Arg_type.create (String.lsplit2_exn ~on:'=')
 
 let converge ~verbose host port stack timeout_seconds poll_interval =
   set_verbose verbose;

--- a/src/cli/sure_deploy.ml
+++ b/src/cli/sure_deploy.ml
@@ -26,8 +26,7 @@ let environment () =
              containing '='")
   >>= String.Map.of_alist_or_error
 
-let registry_access_value =
-  Command.Arg_type.create (String.lsplit2_exn ~on:'=')
+let registry_access_value = Command.Arg_type.create (String.lsplit2_exn ~on:'=')
 
 let converge ~verbose host port stack timeout_seconds poll_interval =
   set_verbose verbose;
@@ -91,7 +90,8 @@ let match_spec_and_service
 let is_insecure_registry image insecure_registries =
   List.mem ~equal:String.equal insecure_registries (Image.registry_full image)
 
-let find_registry_access_token list image = List.Assoc.find ~equal:String.equal list (Image.registry_full image)
+let find_registry_access_token list image =
+  List.Assoc.find ~equal:String.equal list (Image.registry_full image)
 
 let verify ~registry_access_tokens ~insecure_registries ~verbose host port stack
     composefile
@@ -117,9 +117,7 @@ let verify ~registry_access_tokens ~insecure_registries ~verbose host port stack
                      Lib.Requests.image_digest
                        ~image:deployed
                        ~registry_access_token:
-                         (find_registry_access_token
-                            registry_access_tokens
-                            deployed)
+                         (find_registry_access_token registry_access_tokens deployed)
                        ~is_insecure_registry:
                          (is_insecure_registry deployed insecure_registries)
                    in

--- a/src/cli/sure_deploy.ml
+++ b/src/cli/sure_deploy.ml
@@ -85,7 +85,7 @@ let match_spec_and_service
         service_count
         spec_count
 
-let verify host port verbose stack registryaccesstoken composefile =
+let verify host port verbose stack registryaccesstoken insecureregistry composefile =
   let open Deferred.Or_error.Let_syntax in
   set_verbose verbose;
   let swarm = Swarm.of_host_and_port (host, port) in
@@ -119,6 +119,7 @@ let verify host port verbose stack registryaccesstoken composefile =
                        ~name:(Image.name deployed)
                        ~tag:deployed_tag
                        ~registry_access_token:registryaccesstoken
+                       ~insecure_registry:insecureregistry
                    in
                    let%bind desired_hash =
                      Lib.Requests.image_digest
@@ -126,6 +127,7 @@ let verify host port verbose stack registryaccesstoken composefile =
                        ~name:(Image.name desired)
                        ~tag:desired_tag
                        ~registry_access_token:registryaccesstoken
+                       ~insecure_registry:insecureregistry
                    in
                    match String.equal deployed_hash desired_hash with
                    | true -> Deferred.Or_error.return ()
@@ -186,13 +188,19 @@ let () =
             "--registry-access-token"
             (optional_with_default "" string)
             ~doc:" The access token for accessing the registry"
+        and insecureregistry =
+          flag
+            "--insecure-registry"
+            no_arg
+            ~doc:" Communicate with registry over http instead of https"
         and composefile =
           flag
             "--compose-file"
             (optional_with_default "docker-compose.yml" string)
             ~doc:" Compose file to read (default: docker-compose.yml)"
         in
-        fun () -> verify host port verbose stack registryaccesstoken composefile])
+        fun () ->
+          verify host port verbose stack registryaccesstoken insecureregistry composefile])
   in
   Command.group
     ~summary:"Deployment helper for Docker Stack"

--- a/src/cli/sure_deploy.ml
+++ b/src/cli/sure_deploy.ml
@@ -104,29 +104,15 @@ let verify ~registry_access_token ~insecure_registry ~verbose host port stack co
                match Image.equal_nametag desired deployed with
                | true -> Deferred.Or_error.return ()
                | false -> (
-                   let default = "registry.hub.docker.com" in
-                   let deployed_registry =
-                     Option.value ~default @@ Image.registry deployed
-                   in
-                   let desired_registry =
-                     Option.value ~default @@ Image.registry desired
-                   in
-                   let default = "latest" in
-                   let deployed_tag = Option.value ~default @@ Image.tag deployed in
-                   let desired_tag = Option.value ~default @@ Image.tag desired in
                    let%bind deployed_hash =
                      Lib.Requests.image_digest
+                       ~image:deployed
                        ~registry_access_token
                        ~insecure_registry
-                       ~registry:deployed_registry
-                       ~name:(Image.name deployed)
-                       ~tag:deployed_tag
                    in
                    let%bind desired_hash =
                      Lib.Requests.image_digest
-                       ~registry:desired_registry
-                       ~name:(Image.name desired)
-                       ~tag:desired_tag
+                       ~image:desired
                        ~registry_access_token
                        ~insecure_registry
                    in

--- a/src/cli/sure_deploy.ml
+++ b/src/cli/sure_deploy.ml
@@ -91,7 +91,7 @@ let match_spec_and_service
 let is_insecure_registry image insecure_registries =
   List.mem ~equal:String.equal insecure_registries (Image.registry_full image)
 
-let maybe_find_registry_access_token registry_access_token_mappings image =
+let find_registry_access_token registry_access_token_mappings image =
   match
     List.find registry_access_token_mappings ~f:(fun (registry, _) ->
         String.equal registry (Image.registry_full image))
@@ -123,7 +123,7 @@ let verify ~registry_access_tokens ~insecure_registries ~verbose host port stack
                      Lib.Requests.image_digest
                        ~image:deployed
                        ~registry_access_token:
-                         (maybe_find_registry_access_token
+                         (find_registry_access_token
                             registry_access_tokens
                             deployed)
                        ~is_insecure_registry:
@@ -133,7 +133,7 @@ let verify ~registry_access_tokens ~insecure_registries ~verbose host port stack
                      Lib.Requests.image_digest
                        ~image:desired
                        ~registry_access_token:
-                         (maybe_find_registry_access_token registry_access_tokens desired)
+                         (find_registry_access_token registry_access_tokens desired)
                        ~is_insecure_registry:
                          (is_insecure_registry desired insecure_registries)
                    in

--- a/src/lib/requests.ml
+++ b/src/lib/requests.ml
@@ -84,7 +84,7 @@ let finished swarm service_name =
 
 let v2_manifest = "application/vnd.docker.distribution.manifest.v2+json"
 
-let image_digest ~registry ~name ~tag =
+let image_digest ~registry ~name ~tag ~registry_access_token =
   let url =
     Uri.make
       ~scheme:"https"
@@ -93,6 +93,15 @@ let image_digest ~registry ~name ~tag =
       ()
   in
   let headers = Cohttp.Header.init_with "Accept" v2_manifest in
+  let headers =
+    match registry_access_token with
+    | "" -> headers
+    | _ ->
+        Cohttp.Header.add
+          headers
+          "authorization"
+          (Printf.sprintf "Basic %s" registry_access_token)
+  in
   let%bind resp, body = Client.get ~headers url in
   match Response.status resp |> Code.code_of_status with
   | 200 -> (

--- a/src/lib/requests.ml
+++ b/src/lib/requests.ml
@@ -85,10 +85,16 @@ let finished swarm service_name =
 let v2_manifest = "application/vnd.docker.distribution.manifest.v2+json"
 
 let image_digest ~registry ~name ~tag ~registry_access_token =
+  let host, port =
+    match String.rsplit2 ~on:':' registry with
+    | None -> registry, None
+    | Some (host, port) -> host, Some (int_of_string port)
+  in
   let url =
     Uri.make
       ~scheme:"https"
-      ~host:registry
+      ~host
+      ~port:(Option.value ~default:80 port)
       ~path:(Printf.sprintf "/v2/%s/manifests/%s" name tag)
       ()
   in

--- a/src/lib/requests.ml
+++ b/src/lib/requests.ml
@@ -92,7 +92,12 @@ let image_digest ~is_insecure_registry ?(registry_access_token = None) ~image =
     | false -> "https"
   in
   let url =
-    Uri.make ~scheme ~host:(Image.registry image) ?port:(Image.registry_port image) ~path:(Printf.sprintf "/v2/%s/manifests/%s" (Image.name image) (Image.tag image)) ()
+    Uri.make
+      ~scheme
+      ~host:(Image.registry image)
+      ?port:(Image.registry_port image)
+      ~path:(Printf.sprintf "/v2/%s/manifests/%s" (Image.name image) (Image.tag image))
+      ()
   in
   let headers = Cohttp.Header.init_with "Accept" v2_manifest in
   let headers =

--- a/src/lib/requests.ml
+++ b/src/lib/requests.ml
@@ -84,7 +84,9 @@ let finished swarm service_name =
 
 let v2_manifest = "application/vnd.docker.distribution.manifest.v2+json"
 
-let image_digest ?(insecure_registry=false) ?(registry_access_token=None) ~registry ~name ~tag =
+let image_digest ?(insecure_registry = false) ?(registry_access_token = None) ~registry
+    ~name ~tag
+  =
   let host, port =
     match String.rsplit2 ~on:':' registry with
     | None -> registry, None
@@ -96,12 +98,7 @@ let image_digest ?(insecure_registry=false) ?(registry_access_token=None) ~regis
     | false -> "https"
   in
   let url =
-    Uri.make
-      ~scheme
-      ~host
-      ?port
-      ~path:(Printf.sprintf "/v2/%s/manifests/%s" name tag)
-      ()
+    Uri.make ~scheme ~host ?port ~path:(Printf.sprintf "/v2/%s/manifests/%s" name tag) ()
   in
   let headers = Cohttp.Header.init_with "Accept" v2_manifest in
   let headers =

--- a/src/lib/requests.ml
+++ b/src/lib/requests.ml
@@ -84,7 +84,7 @@ let finished swarm service_name =
 
 let v2_manifest = "application/vnd.docker.distribution.manifest.v2+json"
 
-let image_digest ~registry ~name ~tag ~registry_access_token =
+let image_digest ~registry ~name ~tag ~registry_access_token ~insecure_registry =
   let host, port =
     match String.rsplit2 ~on:':' registry with
     | None -> registry, None
@@ -92,7 +92,7 @@ let image_digest ~registry ~name ~tag ~registry_access_token =
   in
   let url =
     Uri.make
-      ~scheme:"https"
+      ~scheme:(if insecure_registry then "http" else "https")
       ~host
       ~port:(Option.value ~default:80 port)
       ~path:(Printf.sprintf "/v2/%s/manifests/%s" name tag)

--- a/src/lib/requests.ml
+++ b/src/lib/requests.ml
@@ -99,7 +99,7 @@ let image_digest ?(insecure_registry=false) ?(registry_access_token=None) ~regis
     Uri.make
       ~scheme
       ~host
-      ~port:(Option.value ~default:80 port)
+      ?port
       ~path:(Printf.sprintf "/v2/%s/manifests/%s" name tag)
       ()
   in

--- a/src/lib/requests.ml
+++ b/src/lib/requests.ml
@@ -8,6 +8,7 @@ module Headers = Cohttp.Header
 module Swarm = Swarm_types.Swarm
 module Stack = Swarm_types.Stack
 module Service = Swarm_types.Service
+module Image = Swarm_types.Image
 
 (* Docker supports a number of different APIs *)
 let api_version = "v1.24"
@@ -84,21 +85,14 @@ let finished swarm service_name =
 
 let v2_manifest = "application/vnd.docker.distribution.manifest.v2+json"
 
-let image_digest ?(insecure_registry = false) ?(registry_access_token = None) ~registry
-    ~name ~tag
-  =
-  let host, port =
-    match String.rsplit2 ~on:':' registry with
-    | None -> registry, None
-    | Some (host, port) -> host, Some (int_of_string port)
-  in
+let image_digest ?(insecure_registry = false) ?(registry_access_token = None) ~image =
   let scheme =
     match insecure_registry with
     | true -> "http"
     | false -> "https"
   in
   let url =
-    Uri.make ~scheme ~host ?port ~path:(Printf.sprintf "/v2/%s/manifests/%s" name tag) ()
+    Uri.make ~scheme ~host:(Image.registry image) ?port:(Image.registry_port image) ~path:(Printf.sprintf "/v2/%s/manifests/%s" (Image.name image) (Image.tag image)) ()
   in
   let headers = Cohttp.Header.init_with "Accept" v2_manifest in
   let headers =

--- a/src/lib/requests.ml
+++ b/src/lib/requests.ml
@@ -85,9 +85,9 @@ let finished swarm service_name =
 
 let v2_manifest = "application/vnd.docker.distribution.manifest.v2+json"
 
-let image_digest ?(insecure_registry = false) ?(registry_access_token = None) ~image =
+let image_digest ~is_insecure_registry ?(registry_access_token = None) ~image =
   let scheme =
-    match insecure_registry with
+    match is_insecure_registry with
     | true -> "http"
     | false -> "https"
   in

--- a/src/lib/swarm_types.ml
+++ b/src/lib/swarm_types.ml
@@ -84,15 +84,16 @@ module Image : sig
 end = struct
   type t = {
     registry : string;
-    registry_port: int option;
+    registry_port : int option;
     name : string;
     tag : string;
     hash : string option;
   }
   [@@deriving eq]
 
-  let default_registry="registry.hub.docker.com"
-  let default_tag="latest"
+  let default_registry = "registry.hub.docker.com"
+
+  let default_tag = "latest"
 
   let parse_name_tag_hash s =
     match String.lsplit2 ~on:':' s with
@@ -117,8 +118,8 @@ end = struct
           let name, tag, hash = parse_name_tag_hash h in
           (* Custom registry could use a custom port *)
           match String.lsplit2 ~on:':' registry with
-            | None -> registry, None, name, tag, hash
-            | Some (registry, port) -> registry, Some (int_of_string port), name, tag, hash
+          | None -> registry, None, name, tag, hash
+          | Some (registry, port) -> registry, Some (int_of_string port), name, tag, hash
         else
           let name, tag, hash = parse_name_tag_hash s in
           default_registry, None, name, tag, hash
@@ -128,21 +129,20 @@ end = struct
     {registry; registry_port; name; tag; hash}
 
 
-  let create ?registry ?registry_port ?tag ?hash name = {
-    registry=(
-      match registry with 
+  let create ?registry ?registry_port ?tag ?hash name =
+    {
+      registry=
+        (match registry with 
         | Some registry -> registry
-        | _ -> default_registry
-    );
-    registry_port;
-    name; 
-    tag=(
-      match tag with
+        | _ -> default_registry);
+      registry_port;
+      name; 
+      tag=
+        (match tag with
         | Some tag -> tag
-        | None -> default_tag
-    );
-    hash
-  }
+        | None -> default_tag);
+      hash
+    }
   
 
 
@@ -182,7 +182,7 @@ end = struct
     equal (of_string "localhost/org/n:t") (create ~registry:"localhost" ~tag:"t" "org/n")
 
   let print_full_registry registry registry_port =
-    match (registry, registry_port) with
+    match registry, registry_port with
       | registry, Some port -> Printf.sprintf "%s:%d/" registry port
       | registry, None -> Printf.sprintf "%s/" registry
   let to_string {registry; registry_port; name; tag; hash} =

--- a/src/lib/swarm_types.ml
+++ b/src/lib/swarm_types.ml
@@ -72,51 +72,77 @@ module Image : sig
 
   val of_yojson : Yojson.Safe.t -> (t, string) result
 
-  val registry : t -> string option
+  val registry : t -> string
+
+  val registry_port : t -> int option
 
   val name : t -> string
 
-  val tag : t -> string option
+  val tag : t -> string
 end = struct
   type t = {
-    registry : string option;
+    registry : string;
+    registry_port: int option;
     name : string;
-    tag : string option;
+    tag : string;
     hash : string option;
   }
   [@@deriving eq]
 
-  let parse_name_default_registry s =
+  let default_registry="registry.hub.docker.com"
+  let default_tag="latest"
+
+  let parse_name_tag_hash s =
     match String.lsplit2 ~on:':' s with
-    | None -> s, None, None
+    | None -> s, default_tag, None
     | Some (name, rest) -> (
       match String.lsplit2 ~on:'@' rest with
-      | None -> name, Some rest, None
-      | Some (tag, hash) -> name, Some tag, Some hash)
+      | None -> name, rest, None
+      | Some (tag, hash) -> name, tag, Some hash)
 
-  let parse_name s =
+  let parse_registry_port_name_tag_hash s =
     match String.lsplit2 ~on:'/' s with
     (* Default Docker Registry *)
     | None ->
-        let name, tag, hash = parse_name_default_registry s in
-        None, name, tag, hash
+        let name, tag, hash = parse_name_tag_hash s in
+        default_registry, None, name, tag, hash
     (* Maybe a Custom Registry *)
     | Some (registry, h) ->
         (* Check for localhost and or TLD *)
         if String.is_substring ~substring:"localhost" registry
            || String.is_substring ~substring:"." registry
         then
-          let name, tag, hash = parse_name_default_registry h in
-          Some registry, name, tag, hash
+          let name, tag, hash = parse_name_tag_hash h in
+          (* Custom registry could use a custom port *)
+          match String.lsplit2 ~on:':' registry with
+            | None -> registry, None, name, tag, hash
+            | Some (registry, port) -> registry, Some (int_of_string port), name, tag, hash
         else
-          let name, tag, hash = parse_name_default_registry s in
-          None, name, tag, hash
+          let name, tag, hash = parse_name_tag_hash s in
+          default_registry, None, name, tag, hash
 
   let of_string s =
-    let registry, name, tag, hash = parse_name s in
-    {registry; name; tag; hash}
+    let registry, registry_port, name, tag, hash = parse_registry_port_name_tag_hash s in
+    {registry; registry_port; name; tag; hash}
 
-  let create ?registry ?tag ?hash name = {registry; name; tag; hash}
+
+  let create ?registry ?registry_port ?tag ?hash name = {
+    registry=(
+      match registry with 
+        | Some registry -> registry
+        | _ -> default_registry
+    );
+    registry_port;
+    name; 
+    tag=(
+      match tag with
+        | Some tag -> tag
+        | None -> default_tag
+    );
+    hash
+  }
+  
+
 
   let%test "plain name" = equal (of_string "n") (create "n")
 
@@ -143,29 +169,26 @@ end = struct
   let%test "registry with port orgname tag" =
     equal
       (of_string "registry.tld:5000/org/n:t")
-      (create ~registry:"registry.tld:5000" ~tag:"t" "org/n")
+      (create ~registry:"registry.tld" ~registry_port:5000 ~tag:"t" "org/n")
 
   let%test "localhost registry with port orgname tag" =
     equal
       (of_string "localhost:5000/org/n:t")
-      (create ~registry:"localhost:5000" ~tag:"t" "org/n")
+      (create ~registry:"localhost" ~registry_port:5000 ~tag:"t" "org/n")
 
   let%test "localhost registry with orgname tag" =
     equal (of_string "localhost/org/n:t") (create ~registry:"localhost" ~tag:"t" "org/n")
 
-  let to_string {registry; name; tag; hash} =
+  let to_string {registry; registry_port; name; tag; hash} =
     let registry_chunk =
-      match registry with
-      | Some r -> Printf.sprintf "%s/" r
-      | None -> ""
+      match (registry, registry_port) with
+      | registry, Some port -> Printf.sprintf "%s:%d/" registry port
+      | registry, None -> Printf.sprintf "%s/" registry
     in
     let tag_chunk =
-      match tag with
-      | None -> ""
-      | Some t -> (
-        match hash with
-        | None -> Printf.sprintf ":%s" t
-        | Some h -> Printf.sprintf ":%s@%s" t h)
+      match hash with
+      | None -> Printf.sprintf ":%s" tag
+      | Some hash -> Printf.sprintf ":%s@%s" tag hash
     in
     Printf.sprintf "%s%s%s" registry_chunk name tag_chunk
 
@@ -180,6 +203,8 @@ end = struct
   let equal_nametag a b = equal (basename a) (basename b)
 
   let registry {registry; _} = registry
+
+  let registry_port {registry_port; _} = registry_port
 
   let tag {tag; _} = tag
 

--- a/src/lib/swarm_types.ml
+++ b/src/lib/swarm_types.ml
@@ -76,7 +76,7 @@ module Image : sig
 
   val registry_port : t -> int option
 
-  val registry_full: t -> string
+  val registry_full : t -> string
 
   val name : t -> string
 
@@ -128,17 +128,10 @@ end = struct
     let registry, registry_port, name, tag, hash = parse_registry_port_name_tag_hash s in
     {registry; registry_port; name; tag; hash}
 
-
-  let create ?(registry = default_registry) ?registry_port ?(tag = default_tag) ?hash name =
-    {
-      registry;
-      registry_port;
-      name; 
-      tag;
-      hash
-    }
-  
-
+  let create ?(registry = default_registry) ?registry_port ?(tag = default_tag) ?hash
+      name
+    =
+    {registry; registry_port; name; tag; hash}
 
   let%test "plain name" = equal (of_string "n") (create "n")
 
@@ -177,11 +170,11 @@ end = struct
 
   let print_full_registry registry registry_port =
     match registry, registry_port with
-      | registry, Some port -> Printf.sprintf "%s:%d/" registry port
-      | registry, None -> Printf.sprintf "%s/" registry
+    | registry, Some port -> Printf.sprintf "%s:%d/" registry port
+    | registry, None -> Printf.sprintf "%s/" registry
+
   let to_string {registry; registry_port; name; tag; hash} =
-    let registry_chunk = print_full_registry registry registry_port
-    in
+    let registry_chunk = print_full_registry registry registry_port in
     let tag_chunk =
       match hash with
       | None -> Printf.sprintf ":%s" tag
@@ -203,7 +196,8 @@ end = struct
 
   let registry_port {registry_port; _} = registry_port
 
-  let registry_full {registry; registry_port; _} = print_full_registry registry registry_port
+  let registry_full {registry; registry_port; _} =
+    print_full_registry registry registry_port
 
   let tag {tag; _} = tag
 

--- a/src/lib/swarm_types.ml
+++ b/src/lib/swarm_types.ml
@@ -95,18 +95,18 @@ end = struct
       | Some (tag, hash) -> name, Some tag, Some hash)
 
   let parse_name s =
-    match String.split ~on:'/' s with
+    match String.lsplit2 ~on:'/' s with
     (* Default Docker Registry *)
-    | [] ->
+    | None ->
         let name, tag, hash = parse_name_default_registry s in
         None, name, tag, hash
     (* Maybe a Custom Registry *)
-    | registry :: h ->
+    | Some (registry, h) ->
         (* Check for localhost and or TLD *)
         if String.is_substring ~substring:"localhost" registry
            || String.is_substring ~substring:"." registry
         then
-          let name, tag, hash = parse_name_default_registry (String.concat ~sep:"/" h) in
+          let name, tag, hash = parse_name_default_registry h in
           Some registry, name, tag, hash
         else
           let name, tag, hash = parse_name_default_registry s in

--- a/src/lib/swarm_types.ml
+++ b/src/lib/swarm_types.ml
@@ -76,6 +76,8 @@ module Image : sig
 
   val registry_port : t -> int option
 
+  val registry_full: t -> string
+
   val name : t -> string
 
   val tag : t -> string
@@ -179,11 +181,12 @@ end = struct
   let%test "localhost registry with orgname tag" =
     equal (of_string "localhost/org/n:t") (create ~registry:"localhost" ~tag:"t" "org/n")
 
-  let to_string {registry; registry_port; name; tag; hash} =
-    let registry_chunk =
-      match (registry, registry_port) with
+  let print_full_registry registry registry_port =
+    match (registry, registry_port) with
       | registry, Some port -> Printf.sprintf "%s:%d/" registry port
       | registry, None -> Printf.sprintf "%s/" registry
+  let to_string {registry; registry_port; name; tag; hash} =
+    let registry_chunk = print_full_registry registry registry_port
     in
     let tag_chunk =
       match hash with
@@ -205,6 +208,8 @@ end = struct
   let registry {registry; _} = registry
 
   let registry_port {registry_port; _} = registry_port
+
+  let registry_full {registry; registry_port; _} = print_full_registry registry registry_port
 
   let tag {tag; _} = tag
 

--- a/src/lib/swarm_types.ml
+++ b/src/lib/swarm_types.ml
@@ -129,18 +129,12 @@ end = struct
     {registry; registry_port; name; tag; hash}
 
 
-  let create ?registry ?registry_port ?tag ?hash name =
+  let create ?(registry = default_registry) ?registry_port ?(tag = default_tag) ?hash name =
     {
-      registry=
-        (match registry with 
-        | Some registry -> registry
-        | _ -> default_registry);
+      registry;
       registry_port;
       name; 
-      tag=
-        (match tag with
-        | Some tag -> tag
-        | None -> default_tag);
+      tag;
       hash
     }
   


### PR DESCRIPTION
I added some new functionality to the library that I need.

# Support Registry Authentication

Closes #19

I implemented it according to the [Amazon ECR Basic Authetication Spec](https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html#registry_auth_http). I am not using any other solution so feedback on whether this implementation is also compatible with other solutions would be nice!

**Example Usage:**

```
sure-deploy verify --host localhost --registry-access-token "abcdefghjhjasd"
```

Using this option will add the following header to the request:

```
Authorization: Basic abcdefghjhjasd
```

# Support custom ports for the docker registry access (and localhost)

Previously using custom ports was not possible. `localhost:5000/hello-world:2` would be parsed incorrectly.

I adjusted the docker registry/name/tag/hash parser so it behaves more like the original implementation [Reference](https://github.com/docker/distribution/blob/release/2.7/reference/normalize.go).

# Insecure HTTP Registry

**Example Usage:**

```
sure-deploy verify --host localhost --insecure-registy "localhost:5000" --insecure-registry "localhost:4999"
```

Using this option will send an `http` instead of an `https` request. Handy for localhost

________


Please note that this is my first time writing ocaml and I am pretty sure that some things could be solved in a better way (especially the changes done to `lib/swarm_types.ml`).

Also, I created a single PR request instead of multiple because, but I can also split it up if required. For now, I will continue using my fork.

The commits are atomic and should be cherry-pickable.



